### PR TITLE
Adds docker image based on fly io pgsql image

### DIFF
--- a/Dockerfile-fly
+++ b/Dockerfile-fly
@@ -1,5 +1,5 @@
 ARG PG_MAJOR=16
-FROM flyio/postgres-flex:$PG_MAJOR
+FROM flyio/postgres-flex:16
 ARG PG_MAJOR
 
 COPY . /tmp/pgvector

--- a/FLY.md
+++ b/FLY.md
@@ -1,0 +1,40 @@
+# Deploying PostgreSQL with pgvector on Fly.io
+
+Vector databases have become essential tools for AI and Machine Learning applications, particularly for similarity searches and embeddings storage. While Fly.io offers a standard PostgreSQL image, it doesn't include the popular `pgvector` extension by default. This guide explains how to deploy a PostgreSQL instance with `pgvector` on Fly.io.
+
+## Prerequisites
+- Docker installed on your local machine
+- Fly.io account and CLI installed
+- Docker Hub account
+
+## Steps to Deploy
+
+### 1. Build and Push the Custom Docker Image
+Build the custom PostgreSQL image with pgvector support:
+```shell
+docker build -f Dockerfile-fly -t <DOCKER_HUB_ACCOUNT>/fly-pgvector . --platform "linux/amd64"  
+docker push <DOCKER_HUB_ACCOUNT>/fly-pgvector
+```
+Replace `<DOCKER_HUB_ACCOUNT>` with your Docker Hub username.
+
+### 2. Create PostgreSQL Cluster
+Deploy the custom PostgreSQL instance on Fly.io:
+```shell
+fly pg create --image-ref <DOCKER_HUB_ACCOUNT>/fly-pgvector --app <APP_NAME>
+```
+Replace `<APP_NAME>` with your desired application name.
+
+### 3. Enable External Access (Optional)
+To access the database from outside Fly.io's network:
+```shell
+fly ips allocate-v4 --app <APP_NAME>
+```
+
+This will assign a public IPv4 address to your database instance.
+
+## Next Steps
+- Configure your application to connect to the database
+- Create tables with vector columns
+- Enable the pgvector extension in your database
+
+For more information about pgvector usage, refer to the [official documentation](https://github.com/pgvector/pgvector).


### PR DESCRIPTION
Adds Fly.io PostgreSQL support with custom Dockerfile and deployment documentation

This change introduces Fly.io-specific Docker configuration and documentation for deploying PostgreSQL with pgvector extension. It modifies the base image from standard postgres:17 to flyio/postgres-flex:16 and adds comprehensive deployment instructions.

### Changes

- Modified base Dockerfile to use flyio/postgres-flex:16 instead of postgres:17
- Added new Dockerfile-fly specifically for Fly.io deployments
- Created FLY.md with detailed deployment documentation and prerequisites

### Impact

- Changes PostgreSQL version from 17 to 16 for compatibility with Fly.io
- Introduces deployment pathway for Fly.io platform users
- Requires Docker Hub account for image distribution
- No direct performance implications, but enables cloud deployment capabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a guide for deploying PostgreSQL with the `pgvector` extension on Fly.io.
- **Chores**
	- Updated PostgreSQL version in the Docker build process.
	- Added a new Dockerfile for building the `pgvector` extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->